### PR TITLE
Fix stats display and favicon sizing issues

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -38,8 +38,8 @@
       </button>
     </div>
 
-    <!-- Queue Count - Grid Layout for Stats -->
-    <div id="queueCount" class="flex items-center justify-center gap-3 text-center text-sm text-neutral-400 py-3 shrink-0">
+    <!-- Queue Count - Stats Line -->
+    <div id="queueCount" class="flex items-center justify-center gap-2.5 text-center text-xs text-neutral-500 py-3 uppercase tracking-wide shrink-0">
       <div id="statsRemaining">Loading...</div>
       <div class="text-neutral-600">•</div>
       <div id="statsPosition"></div>
@@ -56,7 +56,7 @@
         No links yet!
       </h3>
       <div class="flex items-center gap-2">
-        <img id="linkFavicon" src="" alt="" class="w-5 h-5 hidden">
+        <img id="linkFavicon" src="" alt="" class="w-4 h-4 hidden">
         <div id="linkUrl" class="text-xs text-neutral-500 whitespace-nowrap overflow-hidden text-ellipsis"></div>
       </div>
     </div>

--- a/extension/src/popup.js
+++ b/extension/src/popup.js
@@ -282,14 +282,14 @@ function updateQueueCount() {
   }
 
   const remaining = queue.length;
-  statsRemaining.textContent = `${remaining} link${remaining !== 1 ? 's' : ''} remaining`;
+  statsRemaining.textContent = `${remaining} ${remaining !== 1 ? 'links' : 'link'} in queue`;
 
   // Update position and time if we have a current link
   if (currentLink) {
     const position = getChronologicalPosition(currentLink.id);
     const timeAgo = getTimeAgo(currentLink.timestamp);
     statsPosition.textContent = `(${position}/${remaining})`;
-    statsTime.textContent = `Saved ${timeAgo}`;
+    statsTime.textContent = `saved ${timeAgo}`;
   } else {
     statsPosition.textContent = '';
     statsTime.textContent = '';
@@ -375,17 +375,20 @@ openBtn.addEventListener('click', async () => {
   if (currentLink) {
     await openAndRemove(currentLink.id);
     displayRandomLink();
+    updateQueueCount();
   }
 });
 
 skipBtn.addEventListener('click', () => {
   displayRandomLink();
+  updateQueueCount();
 });
 
 deleteBtn.addEventListener('click', async () => {
   if (currentLink) {
     await deleteLink(currentLink.id);
     displayRandomLink();
+    updateQueueCount();
   }
 });
 


### PR DESCRIPTION
- Reduce favicon display size back to w-4 h-4 (keep 64px resolution for quality)
- Restore original stats styling: text-xs, uppercase, tracking-wide
- Change stats text back to "X links in queue" format
- Fix stats not updating: call updateQueueCount() after skip/delete/open
- Stats now update dynamically when changing links