### PR TITLE
Refactor: Extract Firestore operations into services module

### DIFF
--- a/extension/src/services/firestore.js
+++ b/extension/src/services/firestore.js
@@ -1,0 +1,90 @@
+import { db } from '../firebase-config.js';
+import { collection, getDocs, addDoc, deleteDoc, doc, query, where } from 'firebase/firestore';
+
+/**
+ * Load all links from Firestore for a specific user
+ * @param {string} userId - The user's UID
+ * @returns {Promise<Array>} Array of link objects with {id, url, title, timestamp}
+ */
+export async function loadLinksFromFirestore(userId) {
+  if (!userId) {
+    console.log('User not authenticated - cannot load queue');
+    return [];
+  }
+
+  try {
+    // Load all links from Firestore for the current user
+    const linksRef = collection(db, 'users', userId, 'links');
+    const querySnapshot = await getDocs(linksRef);
+
+    const links = [];
+    querySnapshot.forEach((doc) => {
+      links.push({
+        id: doc.id, // Use Firestore document ID
+        url: doc.data().url,
+        title: doc.data().title,
+        timestamp: doc.data().createdAt
+      });
+    });
+
+    console.log(`Loaded ${links.length} links from Firestore`);
+    return links;
+  } catch (error) {
+    console.error('Failed to load queue from Firestore:', error);
+    return [];
+  }
+}
+
+/**
+ * Save a new link to Firestore
+ * @param {string} userId - The user's UID
+ * @param {string} url - The URL to save
+ * @param {string} title - The title of the page (optional, defaults to url)
+ * @returns {Promise<Object>} The saved link object with {id, url, title, timestamp}
+ * @throws {Error} If duplicate or save fails
+ */
+export async function saveLinkToFirestore(userId, url, title) {
+  if (!userId) {
+    throw new Error('User not authenticated');
+  }
+
+  // Check for duplicates in Firestore
+  const linksRef = collection(db, 'users', userId, 'links');
+  const q = query(linksRef, where('url', '==', url));
+  const querySnapshot = await getDocs(q);
+
+  if (!querySnapshot.empty) {
+    throw new Error('DUPLICATE');
+  }
+
+  // Save to Firestore
+  const docRef = await addDoc(collection(db, 'users', userId, 'links'), {
+    url: url,
+    title: title || url,
+    createdAt: Date.now()
+  });
+
+  // Return the new link object
+  return {
+    id: docRef.id,
+    url: url,
+    title: title || url,
+    timestamp: Date.now()
+  };
+}
+
+/**
+ * Delete a link from Firestore
+ * @param {string} userId - The user's UID
+ * @param {string} linkId - The Firestore document ID of the link
+ * @returns {Promise<void>}
+ * @throws {Error} If delete fails
+ */
+export async function deleteLinkFromFirestore(userId, linkId) {
+  if (!userId) {
+    throw new Error('User not authenticated');
+  }
+
+  await deleteDoc(doc(db, 'users', userId, 'links', linkId));
+  console.log('Link deleted from Firestore:', linkId);
+}


### PR DESCRIPTION
- Created src/services/firestore.js with three focused functions:
  - loadLinksFromFirestore(userId)
  - saveLinkToFirestore(userId, url, title)
  - deleteLinkFromFirestore(userId, linkId)

- Simplified popup.js from 439 to 402 lines (37 lines removed)
- Removed Firestore imports and db dependency from popup.js
- Improved code maintainability and reusability
- Service functions now ready for website dashboard integration