### PR TITLE
Fix extension UI improvements

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -15,7 +15,7 @@
       <h2 class="text-xl font-semibold tracking-tight">OneLinkPlease</h2>
 
       <div class="flex items-center gap-2">
-        <div class="text-[8px] leading-tight text-right text-neutral-500 font-semibold uppercase tracking-wide">
+        <div class="text-[10px] leading-tight text-right text-neutral-500 font-semibold uppercase tracking-wide">
           PRODUCTIVITY<br>MODE
         </div>
         <button
@@ -79,7 +79,7 @@
       </button>
       <button
         id="skipBtn"
-        class="flex-1 px-3 py-2.5 bg-neutral-800 text-white border border-[#1a1a1a] rounded-lg text-sm font-medium hover:bg-neutral-700 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        class="flex-1 px-3 py-2.5 bg-neutral-700 text-white border border-[#1a1a1a] rounded-lg text-sm font-medium hover:bg-neutral-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
       >
         Skip
       </button>

--- a/extension/src/popup.js
+++ b/extension/src/popup.js
@@ -221,7 +221,7 @@ function displayRandomLink() {
     linkFavicon.classList.add('link-exit');
   }
 
-  // Wait for exit animation, then update and animate in
+  // Wait for exit animation, then update and animate in (120ms for smooth buffer)
   setTimeout(() => {
     // Show the link
     linkCard.style.display = 'block';
@@ -232,11 +232,19 @@ function displayRandomLink() {
     const domain = simplifyUrl(currentLink.url);
     linkUrl.textContent = domain;
 
-    // Update favicon
+    // Update favicon with preloading to prevent layout shift
     const faviconUrl = getFaviconUrl(currentLink.url);
     if (faviconUrl && linkFavicon) {
-      linkFavicon.src = faviconUrl;
-      linkFavicon.classList.remove('hidden');
+      // Preload favicon before showing it
+      const img = new Image();
+      img.src = faviconUrl;
+      img.onload = () => {
+        linkFavicon.src = faviconUrl;
+        linkFavicon.classList.remove('hidden');
+      };
+      img.onerror = () => {
+        linkFavicon.classList.add('hidden');
+      };
     } else if (linkFavicon) {
       linkFavicon.classList.add('hidden');
     }
@@ -263,7 +271,7 @@ function displayRandomLink() {
       // Clear animation flag
       isAnimating = false;
     }, 200);
-  }, 100);
+  }, 120);
 }
 
 // Update queue count display with stats


### PR DESCRIPTION
- Improved button visual hierarchy: Skip button now uses bg-neutral-700 for better contrast
- Fixed favicon animation timing with image preloading to prevent layout shift
- Increased productivity mode label size from 8px to 10px for better readability
- Fixed animation glitch by adding 20ms buffer between exit and enter animations (100ms -> 120ms)